### PR TITLE
NullPointerException because of uninitialized teams.yml

### DIFF
--- a/src/main/java/com/wasteofplastic/beaconz/Scorecard.java
+++ b/src/main/java/com/wasteofplastic/beaconz/Scorecard.java
@@ -325,7 +325,7 @@ public class Scorecard extends BeaconzPluginDependent{
     public void loadTeamMembers() {
         File teamFile = new File(getBeaconzPlugin().getDataFolder(),"teams.yml");
         if (!teamFile.exists()) {
-            return;
+            saveTeamMembers();
         }
         YamlConfiguration teamsYml = new YamlConfiguration();
         try {


### PR DESCRIPTION
Steps to reproduce:

1. Run server jar in an empty folder to create a new world.
2. Stop server
3. Copy beaconz.jar in plugins folder.
4. Start server again.
5. Log in and run /beaconz
6. `player.teleport(teleportTo)` throws NPE because `teleportTo` is null.

This happens because `Scorecard.teamSpawnPoint` is an empty map. Normally the map is populated by `loadTeamMembers()`. However, when beaconz is started for the first time, `teams.yml` does not yet exists, so `loadTeamMembers()` never initializes the map.

The solution is to create `teams.yml` whenever it doesn't exist, and let `loadTeamMembers()` proceed as normal.